### PR TITLE
Gather basic state information from "apt-cache policy ..."

### DIFF
--- a/src/modules/sapt.py
+++ b/src/modules/sapt.py
@@ -446,9 +446,9 @@ def parse_apt_cache_policy(content):
 
     Returns:
         A dictionary of relevant fields. For example:
-            {'candidate': '3.03+dfsg1-10',
-             'package_name': 'cowsay',
-              'installed': '3.03+dfsg1-10'}
+            {'package_name': 'cowsay',
+             'installed': '3.03+dfsg1-10',
+             'candidate': '3.03+dfsg1-10'}
 
     Output of "apt-cache policy cowsay" (for example) looks like the
     following:


### PR DESCRIPTION
Stefan Taranu gave me feedback on how to use "apt-cache policy <package_name>"
to determine if the package is installed or not.

Although we could get this information from "dpkg-query -W -f=.." in the error
output, we can get this information from "apt-cache policy" without seeing a
command line failure.

Feedback from Stefan Taranu:
> This command can be used to extract the current version of an installed
> package, if it's upgradable, and upgrade candidates.
>
> root@jessie:~# apt-cache policy apt
> apt:
>   Installed: 1.0.9.8.5
>   Candidate: 1.0.9.8.6
>   Version table:
>     1.0.9.8.6 0
>     500 http://security.debian.org/ jessie/updates/main amd64 Packages
>     *** 1.0.9.8.5 0
>     100 /var/lib/dpkg/status
>     1.0.9.8.4 0
>     500 http://httpredir.debian.org/debian/ jessie/main amd64 Packages

> it also shows if a package is not currently installed:
>
> nginx:
>   Installed: (none)
>   Candidate: 1.6.2-5+deb8u6
>   Version table:
>     1.6.2-5+deb8u6 0
>     500 http://security.debian.org/ jessie/updates/main amd64 Packages
>     1.6.2-5+deb8u5 0
>     500 http://httpredir.debian.org/debian/ jessie/main amd64 Packages