### PR TITLE
Correct behaviour for has_package_files

### DIFF
--- a/src/modules/sapt.py
+++ b/src/modules/sapt.py
@@ -584,7 +584,7 @@ def dpkg_files(_ansible_module, package_name):
     _fail_if_error(_ansible_module, cmd, return_code, err)
 
     if "does not contain any files" in out:
-      return []
+        return []
 
     return out.strip().split('\n')
 


### PR DESCRIPTION
* `dpkg` returns exitcode 1 if a package is not installed, this gets handled by `_fail_if_error` and can be handled by the playbook
* `dpkg` returns exitcode 0 and output in the form of `Package ${package} does not contain any files (!)` on stdout (rather than stderr) if a package was previously installed, not purged, but also does not have any files. This case is specifically caught and returns an empty list.
* even in the case that the output from `dpkg` is only a newline (or indeed, empty), `out.strip().split('\n')` would still return `['']` which has length 1, therefor `has_package_files()` should return the results of `any()` which does not consider empty strings in a list as `True` and will thus correctly return `False` if no files are returned.

This should resolve https://github.com/glenjarvis/ansible-simple-apt/issues/8